### PR TITLE
add About page 新增關於頁面

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,13 +21,14 @@ scripts_defer:
 
 
 social:
-  Github: https://github.com/yours
-  Codepen: https://codepen.io/yours
-  Dribbble: https://dribbble.com/yours
-  Twitter: https://twitter.com/yours
-  知乎: https://www.zhihu.com/people/yours
-  掘金: https://juejin.im/user/yours
-  Mail: mailto:xxx@yourmail.xxxx
+  Github: https://github.com/ginagigo123
+  #Codepen: https://codepen.io/yours
+  #Dribbble: https://dribbble.com/yours
+  #Twitter: https://twitter.com/yours
+  #知乎: https://www.zhihu.com/people/yours
+  #掘金: https://juejin.im/user/yours
+  Mail: mailto:ginagigo123@gmail.com
+  Facebook: https://www.facebook.com/profile.php?id=100002255246449
   # and more, you can add other link by the same way
 
 # Uncomment to disable sidebar

--- a/layout/about.pug
+++ b/layout/about.pug
@@ -1,0 +1,25 @@
+extends ./includes/layout.pug
+include ./mixins/postItem.pug
+include ./mixins/horizontalLine.pug
+
+
+block content
+  .main
+    include ./includes/location-bar.pug
+    .main__2-col
+      article.post-view__article
+        .article__infomation
+          - const post = { date: page.date, title: page.title, path: ''}
+          +postItem(post)
+        .article__content
+          != page.content
+      .post-view__sidebar
+        include includes/sidebar.pug
+    +horizontalLine('1px')
+    .main__bottom
+      .back-to-home 
+        a.home-button(href=url_for(theme.Home)) Home
+      if page.content && theme.comment && theme.comment.enable
+        #comments
+
+

--- a/layout/includes/footer.pug
+++ b/layout/includes/footer.pug
@@ -1,7 +1,4 @@
 .footer
-  span ©️2019-#{new Date().getFullYear()} Designed By&nbsp;
+  span ©️2021-#{new Date().getFullYear()} Blog Owned By&nbsp;
     strong
-      a(href='https://github.com/random-yang') RandomYang
-    |  Powered By&nbsp;
-  strong
-    a(href='https://hexo.io') hexo
+      a(href='https://github.com/ginagigo123') Ginagigo123.

--- a/layout/includes/location-bar.pug
+++ b/layout/includes/location-bar.pug
@@ -1,7 +1,7 @@
 include ../mixins/horizontalLine.pug
 
 - let getLocation = function() {
--   let location = '首页'
+-   let location = 'Home'
 -   if (is_page()) location = page.title
 -   if (is_post()) location = page.title
 -   if (is_archive()) location = 'Archive'

--- a/layout/includes/main.pug
+++ b/layout/includes/main.pug
@@ -9,3 +9,4 @@ include ../mixins/horizontalLine.pug
   +horizontalLine('1px')
   .main__bottom
     include ./paginator.pug
+    

--- a/layout/includes/pre-next.pug
+++ b/layout/includes/pre-next.pug
@@ -2,10 +2,10 @@
   if(page.prev)
     a.pre-button(href=url_for(page.prev.path))= page.prev.title
   else
-    a.pre-button 没有更多
+    a.pre-button 沒有更多
 
   if(page.next)
     a.next-button(href=url_for(page.next.path))= page.next.title
   else
-    a.next-button 没有更多
+    a.next-button 沒有更多
     

--- a/layout/includes/sidebar.pug
+++ b/layout/includes/sidebar.pug
@@ -1,4 +1,11 @@
 .sidebar
+  if theme.profile === undefined || theme.profile === true
+    h2 About me
+    .sidebar__profile
+      a(href=theme.menu.About)
+        img(src='/images/profile.jpg' alt="profile")
+      //- a(href=theme.menu.About)  #{config.title}
+
   //- 默认参数 true
   if !page.posts && (theme.toc === undefind || theme.toc === true)
     include ./toc

--- a/source/css/includes/_main.styl
+++ b/source/css/includes/_main.styl
@@ -10,6 +10,22 @@
   padding: 0 2rem
   max-width: 98rem
 
+.main .back-to-home
+  display: flex
+  justify-content: center
+  padding: 5.5rem 3.5rem
+
+.main .home-button
+  font-size: 1.4rem
+  font-weight: bold
+  line-height: 2.2rem
+  box-shadow: inset 0 -0.1em 0 $color-black-2
+  transition:all .3s cubic-bezier(.71,0,0,.99)
+  text-decoration: none
+  &:hover
+    box-shadow: inset 0 -0.8em 0 $color-main
+  
+
 @media screen and (max-width: $S)
   .main, .page
     .main__2-col

--- a/source/css/includes/_sidebar.styl
+++ b/source/css/includes/_sidebar.styl
@@ -28,6 +28,16 @@
   &__button
     display: none
 
+  &__profile
+    img
+      width: 150px;
+      border-radius: 50%;
+      margin:1.6rem 0 0.6rem 1rem
+      &:hover
+        transition: all .2s ease-in-out
+        transform: scale(1.1)  
+
+
 @media screen and (max-width: $S)
   .sidebar
     width: 100%


### PR DESCRIPTION
您好：
很喜欢你的设计，但是希望加上一个「关于」页面，所以我有试着做新增About me的内容：
不过这是我第一次pull，如果有哪里说明得不好，再麻烦您告知！

以下是我做的改变：
1. 在原本的主页面上新增了About me，可以放入用户头像
用户头像需要放置 `source/images/profile.jpg`
![image](https://user-images.githubusercontent.com/46167389/124384579-88d1f180-dd04-11eb-9db6-a75d48eca692.png)

2. 点击用户头像可进入/about页面
这部分需要在`source`资料夹新建文件`about`
不过采用 `hexo new page about` 的方式新建文件，这样可以被 hexo索引到

在about页面的最下面还有home可以回到首页
![image](https://user-images.githubusercontent.com/46167389/124384914-13672080-dd06-11eb-85b5-a129b2449b42.png)